### PR TITLE
Add status filter and links for assessment results

### DIFF
--- a/admin/tool/assesmentresults/classes/output/index_page.php
+++ b/admin/tool/assesmentresults/classes/output/index_page.php
@@ -11,7 +11,7 @@ class index_page implements renderable, templatable {
 
     public function __construct($arr, $coursestr, $assessmentstr, $studentsstr, $studentsstrusername,
             $page, $total, $poststudentname, $postcoursename, $postassessmentname, $poststudentusername,
-            $cid, $aid, $sid, $suid, $sortval, $sortvalold, $sorttype, $showallstudent, $selectterm,
+            $cid, $aid, $sid, $suid, $selectedstatus, $sortval, $sortvalold, $sorttype, $showallstudent, $selectterm,
             $selectyear, $years) {
         $this->arr = $arr; 
         $this->coursestr = $coursestr;
@@ -28,6 +28,7 @@ class index_page implements renderable, templatable {
         $this->aid = $aid;
         $this->sid = $sid;
         $this->suid = $suid;
+        $this->selectedstatus = $selectedstatus;
         $this->sortval = $sortval;
 		$this->sortvalold = $sortvalold;
         $this->sorttype = $sorttype;
@@ -54,6 +55,15 @@ class index_page implements renderable, templatable {
         $data->aid = $this->aid;
         $data->sid = $this->sid;
         $data->suid = $this->suid;
+        $data->selectedstatus = $this->selectedstatus;
+        $data->statusoptions = [
+            ['code' => '', 'label' => 'All Statuses', 'selected' => ($this->selectedstatus === '')],
+            ['code' => 'satisfactory', 'label' => 'Satisfactory', 'selected' => ($this->selectedstatus === 'satisfactory')],
+            ['code' => 'notsatisfactory', 'label' => 'Not Satisfactory', 'selected' => ($this->selectedstatus === 'notsatisfactory')],
+            ['code' => 'notyetgraded', 'label' => 'Not Yet Graded', 'selected' => ($this->selectedstatus === 'notyetgraded')],
+            ['code' => 'nosubmission', 'label' => 'No Submission', 'selected' => ($this->selectedstatus === 'nosubmission')],
+            ['code' => 'openattempt', 'label' => 'Open Attempt', 'selected' => ($this->selectedstatus === 'openattempt')],
+        ];
         $data->sortval = $this->sortval;
 		$data->sortvalold = $this->sortvalold;
         $data->sorttype = $this->sorttype;

--- a/admin/tool/assesmentresults/lang/en/tool_assesmentresults.php
+++ b/admin/tool/assesmentresults/lang/en/tool_assesmentresults.php
@@ -42,3 +42,16 @@ $string['transferdbintro'] = 'This script will transfer the entire contents of t
 $string['transferdbtoserver'] = 'Transfer this Moodle database to another server';
 $string['transferringdbto'] = 'Transferring this {$a->dbtypefrom} database to {$a->dbtype} database "{$a->dbname}" on "{$a->dbhost}"';
 
+$string['filter_status'] = 'Status';
+$string['status_satisfactory'] = 'Satisfactory';
+$string['status_notsatisfactory'] = 'Not Satisfactory';
+$string['status_notyetgraded'] = 'Not Yet Graded';
+$string['status_nosubmission'] = 'No Submission';
+$string['status_openattempt'] = 'Open Attempt';
+$string['col_assessment'] = 'ASSESSMENT';
+$string['col_studentname'] = 'STUDENT NAME';
+$string['col_status'] = 'STATUS';
+$string['col_trainergrader'] = 'TRAINER/GRADER';
+$string['col_actiontraineracademic'] = 'ACTION FOR TRAINER & ACADEMIC';
+$string['col_studentsubmissionlink'] = 'STUDENT SUBMISSION LINK';
+$string['col_observationchecklist'] = 'OBSERVATION CHECKLIST';

--- a/admin/tool/assesmentresults/templates/index_page.mustache
+++ b/admin/tool/assesmentresults/templates/index_page.mustache
@@ -140,13 +140,20 @@ ul.pagination li a:hover:not(.active) {background-color: #ddd;}
     <input id="studentname" type="text" name="studentname" placeholder="Type your Student Name..." value="{{{poststudentname}}}" >
  <input id="studentid" type="hidden" name="studentid" value="{{{sid}}}" />
   </div>
-  
+
+</td>
+<td>
+  <select name="status" id="status">
+    {{#statusoptions}}
+    <option value="{{code}}"{{#selected}} selected{{/selected}}>{{label}}</option>
+    {{/statusoptions}}
+  </select>
 </td>
 <td><div class="autocomplete" style="width:195px;">
     <input id="studentusername" type="text" name="studentusername" placeholder="Type your Student User Name..." value="{{{poststudentusername}}}" >
  <input id="studentuserid" type="hidden" name="studentuserid" value="{{{suid}}}" />
   </div>
-  
+
 </td>
 <td><input class="myButton" type="submit" name="search" id="search" value=" Search " onclick="javascript: if(document.getElementById('coursename').value=='' && document.getElementById('studentname').value=='' && document.getElementById('studentusername').value=='') { alert('Please select any course or student from the drop down list only!'); return false; }" /></td>
 <td>&nbsp;</td><td><input class="myButton" type="button" onclick="javascript: window.location.href='index.php?showall=1';" name="showall" id="showall" value=" Reset " /></td></tr></table>
@@ -199,13 +206,15 @@ ul.pagination li a:hover:not(.active) {background-color: #ddd;}
 <form action="" method="POST" name="f" id="f" autocomplete="off">
 
 <table cellspacing="11" cellpadding="10" style="border: 1px solid #aaa;font-size: 14px!important;" width="100%">                                 
-<tr style="background-color: #ddd; font-weight: bold;"><td>ID</td><td><a href="index.php?sorttype=assignment&sort={{{sortval}}}&showallstudent={{{showallstudent}}}" title="Click to sort">ASSIGNMENT</a></td><td>STUDENT</td><td>RESULT</td><td>TRAINER/GRADER</td><td>OBSERVATION CHECKLIST</td></tr>                                                                            
+<tr style="background-color: #ddd; font-weight: bold;"><td>ID</td><td><a href="index.php?sorttype=assignment&sort={{{sortval}}}&showallstudent={{{showallstudent}}}" title="Click to sort">ASSESSMENT</a></td><td>STUDENT NAME</td><td>STATUS</td><td>TRAINER/GRADER</td><td>ACTION FOR TRAINER & ACADEMIC</td><td>STUDENT SUBMISSION LINK</td><td>OBSERVATION CHECKLIST</td></tr>
   {{#user}}                                                                                                             
   <tr><td>{{rowid}}</td>   
           <td><a href="ajax/assignment.php?id={{assignmentid}}&showallstudent={{{showallstudent}}}" rel="modal:open">{{assignmentname}}</a></td>
           <td><a href="ajax/user.php?id={{userid}}" rel="modal:open">{{name}}</a></td>
-         <td>{{result}}</td>
+         <td>{{statuslabel}}</td>
 <td>{{gradername}}</td>
+<td>{{{actionlinks}}}</td>
+<td>{{{studentsubmissionlink}}}</td>
 <td>{{#obs_url}} <a href="{{obs_url}}" target="_blank">{{obs_url}}</a>{{/obs_url}}{{^obs_url}}NA{{/obs_url}}</td>
 </tr>    <input type="hidden" name="updateid" id="updateid" value="{{rowid}}" />
  


### PR DESCRIPTION
## Summary
- add status filter and propagate across pagination and export
- include action/student submission links and status columns in table and excel export
- provide language strings for status values and column headings

## Testing
- `php -l admin/tool/assesmentresults/index.php`
- `php -l admin/tool/assesmentresults/createexcel.php`
- `php -l admin/tool/assesmentresults/classes/output/index_page.php`


------
https://chatgpt.com/codex/tasks/task_e_6895d6fe8ae48331a84188bb8711f5ec