### PR TITLE
Restrict final grade lookup to course item

### DIFF
--- a/grade/report/overview/studentgrades.php
+++ b/grade/report/overview/studentgrades.php
@@ -1016,24 +1016,17 @@ $list = $DB->get_records_sql($sql);
 
 $sql_finalcompetency = "SELECT gi.gradetype, gi.scaleid, gg.finalgrade FROM {grade_items} gi "
         . "JOIN {grade_grades} gg ON gg.itemid = gi.id "
-        . "WHERE gi.courseid = '".$val[2]->id."' AND gg.userid = '".$userid."' AND gi.itemname = 'Final Competency'";
+        . "WHERE gi.courseid = '".$val[2]->id."' AND gg.userid = '".$userid."' "
+        . "AND gi.itemtype = 'course' ORDER BY gi.id DESC LIMIT 1";
 $finalrecord = $DB->get_record_sql($sql_finalcompetency);
-$finalcompetency = '';
-if($finalrecord)
-{
-    if($finalrecord->scaleid>0 && $finalrecord->gradetype!=1)
-    {
+$finalcompetency = "NA / Not yet graded";
+if ($finalrecord) {
+    if ($finalrecord->scaleid > 0 && $finalrecord->gradetype != 1) {
         $grade_val = intval($finalrecord->finalgrade);
-        @$finalcompetency = $scale_array[$finalrecord->scaleid][$grade_val];
-    }
-    else
-    {
+        $finalcompetency = $scale_array[$finalrecord->scaleid][$grade_val] ?? "NA / Not yet graded";
+    } else {
         $finalcompetency = $finalrecord->finalgrade;
     }
-}
-if(@$finalcompetency=='')
-{
-    $finalcompetency = "NA / Not yet graded";
 }
 
 $arr = array();


### PR DESCRIPTION
## Summary
- Only fetch most recent course-level grade item for final competency
- Show `NA / Not yet graded` when no course grade item exists

## Testing
- `php -l grade/report/overview/studentgrades.php`
- `composer install --no-interaction --no-progress --optimize-autoloader` *(fails: package requirements conflict with PHP 8.4)*
- `vendor/bin/phpunit grade/report/overview/tests/externallib_test.php` *(fails: no such file or directory)*
- `php grade/report/overview/studentgrades.php` *(fails: missing configuration setup.php)*

------
https://chatgpt.com/codex/tasks/task_e_68b971f1e9808331a6f0d8100052c342