### PR TITLE
Include course ID in student grade search results

### DIFF
--- a/grade/report/overview/studentgrades.php
+++ b/grade/report/overview/studentgrades.php
@@ -1069,7 +1069,7 @@ foreach($list as $list)
             }
             $grade_exists = '';
             $activitydate = @date("F j, Y, g:i a",$list->activitydate);
-            $arr[] = array('baseurl'=>$CFG->wwwroot,'rowid'=>$list->rowid,'userid'=>$list->userid, 'name'=>$list->firstname.' '.$list->lastname, 'username'=>$list->username , 'assignmentname'=>$list->assignmentname,'assignmentid'=>$list->assignmentid,'grademin'=>$list->grademin,'grademax'=>$list->grademax,'timemodified'=>$timemodified,'timemodifiedg'=>'','gradeexists'=>$grade_exists,"result"=>$scale_text,"status"=>$list->status,"feedback"=>$list->feedback,"itemidother"=>$list->itemidother,"feedbackposted1"=>@$list->feedbackposted1,"feedbackposted2"=>@$list->feedbackposted2,"moduleid"=>$list_module->id,'activitydate'=>$activitydate,'countsubmission'=>$list->countsubmission,'finalcompetency'=>$finalcompetency);
+            $arr[] = array('baseurl'=>$CFG->wwwroot,'rowid'=>$list->rowid,'userid'=>$list->userid,'courseid'=>$list->courseid, 'name'=>$list->firstname.' '.$list->lastname, 'username'=>$list->username , 'assignmentname'=>$list->assignmentname,'assignmentid'=>$list->assignmentid,'grademin'=>$list->grademin,'grademax'=>$list->grademax,'timemodified'=>$timemodified,'timemodifiedg'=>'','gradeexists'=>$grade_exists,"result"=>$scale_text,"status"=>$list->status,"feedback"=>$list->feedback,"itemidother"=>$list->itemidother,"feedbackposted1"=>@$list->feedbackposted1,"feedbackposted2"=>@$list->feedbackposted2,"moduleid"=>$list_module->id,'activitydate'=>$activitydate,'countsubmission'=>$list->countsubmission,'finalcompetency'=>$finalcompetency);
             unset($grade_val);
             unset($scale_text);
             unset($timemodified);
@@ -1095,7 +1095,7 @@ foreach($list as $list)
             }
             $grade_exists = '';
             $activitydate = @date("F j, Y, g:i a",$list->activitydate);
-            $arr[] = array('baseurl'=>$CFG->wwwroot,'rowid'=>$list->rowid,'userid'=>$list->userid, 'name'=>$list->firstname.' '.$list->lastname, 'username'=>$list->username , 'assignmentname'=>$list->assignmentname,'assignmentid'=>$list->assignmentid,'grademin'=>$list->grademin,'grademax'=>$list->grademax,'timemodified'=>$timemodified,'timemodifiedg'=>'','gradeexists'=>$grade_exists,"result"=>$scale_text,"status"=>$list->status,"feedback"=>$list->feedback,"itemidother"=>$list->itemidother,"feedbackposted1"=>$list->feedbackposted1,"feedbackposted2"=>$list->feedbackposted2,"moduleid"=>$list_module->id,'activitydate'=>$activitydate,'countsubmission'=>$list->countsubmission,'finalcompetency'=>$finalcompetency);
+            $arr[] = array('baseurl'=>$CFG->wwwroot,'rowid'=>$list->rowid,'userid'=>$list->userid,'courseid'=>$list->courseid, 'name'=>$list->firstname.' '.$list->lastname, 'username'=>$list->username , 'assignmentname'=>$list->assignmentname,'assignmentid'=>$list->assignmentid,'grademin'=>$list->grademin,'grademax'=>$list->grademax,'timemodified'=>$timemodified,'timemodifiedg'=>'','gradeexists'=>$grade_exists,"result"=>$scale_text,"status"=>$list->status,"feedback"=>$list->feedback,"itemidother"=>$list->itemidother,"feedbackposted1"=>$list->feedbackposted1,"feedbackposted2"=>$list->feedbackposted2,"moduleid"=>$list_module->id,'activitydate'=>$activitydate,'countsubmission'=>$list->countsubmission,'finalcompetency'=>$finalcompetency);
            unset($grade_val);
             unset($scale_text);
             unset($timemodified);   
@@ -1134,7 +1134,7 @@ else if($list->scaleid=='' && $list->gradetype==1)
             }
             $grade_exists = '';
             $activitydate = @date("F j, Y, g:i a",$list->activitydate);
-            $arr[] = array('baseurl'=>$CFG->wwwroot,'rowid'=>$list->rowid,'userid'=>$list->userid, 'name'=>$list->firstname.' '.$list->lastname, 'username'=>$list->username , 'assignmentname'=>$list->assignmentname,'assignmentid'=>$list->assignmentid,'grademin'=>$list->grademin,'grademax'=>$list->grademax,'timemodified'=>$timemodified,'timemodifiedg'=>'','gradeexists'=>$grade_exists,"result"=>$scale_text,"status"=>$list->status,"feedback"=>$list->feedback,"itemidother"=>$list->itemidother,"feedbackposted1"=>$list->feedbackposted1,"feedbackposted2"=>$list->feedbackposted2,"moduleid"=>$list_module->id,'activitydate'=>$activitydate,'countsubmission'=>$list->countsubmission,'finalcompetency'=>$finalcompetency);
+            $arr[] = array('baseurl'=>$CFG->wwwroot,'rowid'=>$list->rowid,'userid'=>$list->userid,'courseid'=>$list->courseid, 'name'=>$list->firstname.' '.$list->lastname, 'username'=>$list->username , 'assignmentname'=>$list->assignmentname,'assignmentid'=>$list->assignmentid,'grademin'=>$list->grademin,'grademax'=>$list->grademax,'timemodified'=>$timemodified,'timemodifiedg'=>'','gradeexists'=>$grade_exists,"result"=>$scale_text,"status"=>$list->status,"feedback"=>$list->feedback,"itemidother"=>$list->itemidother,"feedbackposted1"=>$list->feedbackposted1,"feedbackposted2"=>$list->feedbackposted2,"moduleid"=>$list_module->id,'activitydate'=>$activitydate,'countsubmission'=>$list->countsubmission,'finalcompetency'=>$finalcompetency);
            unset($grade_val);
             unset($scale_text);
             unset($timemodified);
@@ -1168,7 +1168,7 @@ else if($list->scaleid=='' && $list->gradetype==1)
             }
             $activitydate = @date("F j, Y, g:i a",$list->activitydate);
             $grade_exists = '';
-            $arr[] = array('baseurl'=>$CFG->wwwroot,'rowid'=>$list->rowid,'userid'=>$list->userid, 'name'=>$list->firstname.' '.$list->lastname, 'username'=>$list->username , 'assignmentname'=>$list->assignmentname,'assignmentid'=>$list->assignmentid,'grademin'=>$list->grademin,'grademax'=>$list->grademax,'timemodified'=>$timemodified,'timemodifiedg'=>'','gradeexists'=>$grade_exists,"result"=>$scale_text,"status"=>$list->status,"feedback"=>$list->feedback,"itemidother"=>$list->itemidother,"feedbackposted1"=>$list->feedbackposted1,"feedbackposted2"=>$list->feedbackposted2,"moduleid"=>$list_module->id,'activitydate'=>$activitydate,'countsubmission'=>$list->countsubmission,'finalcompetency'=>$finalcompetency);
+            $arr[] = array('baseurl'=>$CFG->wwwroot,'rowid'=>$list->rowid,'userid'=>$list->userid,'courseid'=>$list->courseid, 'name'=>$list->firstname.' '.$list->lastname, 'username'=>$list->username , 'assignmentname'=>$list->assignmentname,'assignmentid'=>$list->assignmentid,'grademin'=>$list->grademin,'grademax'=>$list->grademax,'timemodified'=>$timemodified,'timemodifiedg'=>'','gradeexists'=>$grade_exists,"result"=>$scale_text,"status"=>$list->status,"feedback"=>$list->feedback,"itemidother"=>$list->itemidother,"feedbackposted1"=>$list->feedbackposted1,"feedbackposted2"=>$list->feedbackposted2,"moduleid"=>$list_module->id,'activitydate'=>$activitydate,'countsubmission'=>$list->countsubmission,'finalcompetency'=>$finalcompetency);
            unset($grade_val);
             unset($scale_text);
             unset($timemodified);           
@@ -1215,7 +1215,7 @@ if($list_all_count>0) {
 	//$textWithoutLastWord = str_replace('SUBMISSION','',$val['assignmentname']);
 	//$arr_assignname = explode(" ",$val['assignmentname']);
 	//$textWithoutLastWord = $arr_assignname[0]." ".$arr_assignname[1]." ".$arr_assignname[2]." ".$arr_assignname[3];
-	$rate = getObservationChecklistRating($list->userid,$list->courseid,$val['assignmentname']);
+        $rate = getObservationChecklistRating($val['userid'],$val['courseid'],$val['assignmentname']);
 	if($rate!='')
 	{
 		$rate_percentage = $rate;


### PR DESCRIPTION
## Summary
- Add course ID to each search result entry in student grade overview
- Use result entry user and course IDs when fetching observation checklist ratings

## Testing
- `php -l grade/report/overview/studentgrades.php`
- `vendor/bin/phpunit grade/report/overview/tests/externallib_test.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b97502ef7c8331b7e1a74204afb86f